### PR TITLE
Added set filter state action

### DIFF
--- a/Actions/SetFilterStateAction.cs
+++ b/Actions/SetFilterStateAction.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json.Linq;
+using SuchByte.MacroDeck.ActionButton;
+using SuchByte.MacroDeck.GUI;
+using SuchByte.MacroDeck.GUI.CustomControls;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.OBSWebSocketPlugin.GUI;
+using SuchByte.OBSWebSocketPlugin.Language;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SuchByte.OBSWebSocketPlugin.Actions
+{
+    public class SetFilterStateAction : PluginAction
+    {
+        public override string Name => PluginLanguageManager.PluginStrings.ActionFilterState;
+
+        public override string Description => PluginLanguageManager.PluginStrings.ActionFilterStateDescription;
+
+        public override bool CanConfigure => true;
+
+        public override void Trigger(string clientId, ActionButton actionButton)
+        {
+            if (!PluginInstance.Main.OBS.IsConnected) return;
+            if (!String.IsNullOrWhiteSpace(this.Configuration))
+            {
+                try
+                {
+                    JObject configurationObject = JObject.Parse(this.Configuration);
+                    string sceneName = configurationObject["sceneName"].ToString();
+                    string sourceName = configurationObject["sourceName"].ToString();
+                    string filterName = configurationObject["filterName"].ToString();
+
+                    string targetName = String.IsNullOrWhiteSpace(sourceName) ? sceneName : sourceName;
+
+                    switch (configurationObject["method"].ToString())
+                    {
+                        case "hide":
+                            PluginInstance.Main.OBS.SetSourceFilterVisibility(targetName, filterName, false);
+                            break;
+                        case "show":
+                            PluginInstance.Main.OBS.SetSourceFilterVisibility(targetName, filterName, true);
+                            break;
+                        case "toggle":
+                            PluginInstance.Main.OBS.SetSourceFilterVisibility(targetName, filterName, !PluginInstance.Main.OBS.GetSourceFilterInfo(targetName, filterName).IsEnabled);
+                            break;
+                    }
+                }
+                catch { }
+            }
+        }
+
+        public override ActionConfigControl GetActionConfigControl(ActionConfigurator actionConfigurator)
+        {
+            return new FilterSelector(this, actionConfigurator);
+        }
+    }
+}

--- a/GUI/FilterSelector.Designer.cs
+++ b/GUI/FilterSelector.Designer.cs
@@ -1,0 +1,253 @@
+﻿
+namespace SuchByte.OBSWebSocketPlugin.GUI
+{
+    partial class FilterSelector
+    {
+        /// <summary> 
+        /// Erforderliche Designervariable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Verwendete Ressourcen bereinigen.
+        /// </summary>
+        /// <param name="disposing">True, wenn verwaltete Ressourcen gelöscht werden sollen; andernfalls False.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Vom Komponenten-Designer generierter Code
+
+        /// <summary> 
+        /// Erforderliche Methode für die Designerunterstützung. 
+        /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.btnReloadSources = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
+            this.sourcesBox = new SuchByte.MacroDeck.GUI.CustomControls.RoundedComboBox();
+            this.lblSource = new System.Windows.Forms.Label();
+            this.radioToggle = new System.Windows.Forms.RadioButton();
+            this.radioShow = new System.Windows.Forms.RadioButton();
+            this.radioHide = new System.Windows.Forms.RadioButton();
+            this.btnReloadScenes = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
+            this.scenesBox = new SuchByte.MacroDeck.GUI.CustomControls.RoundedComboBox();
+            this.lblScene = new System.Windows.Forms.Label();
+            this.filtersBox = new SuchByte.MacroDeck.GUI.CustomControls.RoundedComboBox();
+            this.lblFilter = new System.Windows.Forms.Label();
+            this.btnReloadFilters = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
+            this.SuspendLayout();
+            // 
+            // btnReloadSources
+            // 
+            this.btnReloadSources.BorderRadius = 8;
+            this.btnReloadSources.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnReloadSources.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReloadSources.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnReloadSources.ForeColor = System.Drawing.Color.White;
+            this.btnReloadSources.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(89)))), ((int)(((byte)(184)))));
+            this.btnReloadSources.Icon = global::SuchByte.OBSWebSocketPlugin.Properties.Resources.reload;
+            this.btnReloadSources.Location = new System.Drawing.Point(555, 76);
+            this.btnReloadSources.Name = "btnReloadSources";
+            this.btnReloadSources.Progress = 0;
+            this.btnReloadSources.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(46)))), ((int)(((byte)(94)))));
+            this.btnReloadSources.Size = new System.Drawing.Size(30, 30);
+            this.btnReloadSources.TabIndex = 14;
+            this.btnReloadSources.UseVisualStyleBackColor = true;
+            this.btnReloadSources.UseWindowsAccentColor = true;
+            this.btnReloadSources.Click += new System.EventHandler(this.BtnReloadSources_Click);
+            // 
+            // sourcesBox
+            // 
+            this.sourcesBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.sourcesBox.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.sourcesBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.sourcesBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.sourcesBox.Icon = null;
+            this.sourcesBox.Location = new System.Drawing.Point(248, 76);
+            this.sourcesBox.Name = "sourcesBox";
+            this.sourcesBox.Padding = new System.Windows.Forms.Padding(8, 2, 8, 2);
+            this.sourcesBox.SelectedIndex = -1;
+            this.sourcesBox.SelectedItem = null;
+            this.sourcesBox.Size = new System.Drawing.Size(301, 30);
+            this.sourcesBox.TabIndex = 13;
+            this.sourcesBox.SelectedIndexChanged += new System.EventHandler(this.sourcesBox_SelectedIndexChanged);
+            // 
+            // lblSource
+            // 
+            this.lblSource.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblSource.Location = new System.Drawing.Point(129, 76);
+            this.lblSource.Name = "lblSource";
+            this.lblSource.Size = new System.Drawing.Size(113, 30);
+            this.lblSource.TabIndex = 12;
+            this.lblSource.Text = "Source:";
+            this.lblSource.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // radioToggle
+            // 
+            this.radioToggle.Checked = true;
+            this.radioToggle.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.radioToggle.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.radioToggle.Location = new System.Drawing.Point(235, 242);
+            this.radioToggle.Name = "radioToggle";
+            this.radioToggle.Size = new System.Drawing.Size(245, 22);
+            this.radioToggle.TabIndex = 11;
+            this.radioToggle.TabStop = true;
+            this.radioToggle.Text = "Toggle";
+            this.radioToggle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.radioToggle.UseVisualStyleBackColor = true;
+            // 
+            // radioShow
+            // 
+            this.radioShow.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.radioShow.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.radioShow.Location = new System.Drawing.Point(235, 204);
+            this.radioShow.Name = "radioShow";
+            this.radioShow.Size = new System.Drawing.Size(245, 22);
+            this.radioShow.TabIndex = 10;
+            this.radioShow.Text = "Show";
+            this.radioShow.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.radioShow.UseVisualStyleBackColor = true;
+            // 
+            // radioHide
+            // 
+            this.radioHide.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.radioHide.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.radioHide.Location = new System.Drawing.Point(235, 165);
+            this.radioHide.Name = "radioHide";
+            this.radioHide.Size = new System.Drawing.Size(245, 22);
+            this.radioHide.TabIndex = 9;
+            this.radioHide.Text = "Hide";
+            this.radioHide.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.radioHide.UseVisualStyleBackColor = true;
+            // 
+            // btnReloadScenes
+            // 
+            this.btnReloadScenes.BorderRadius = 8;
+            this.btnReloadScenes.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnReloadScenes.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReloadScenes.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnReloadScenes.ForeColor = System.Drawing.Color.White;
+            this.btnReloadScenes.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(89)))), ((int)(((byte)(184)))));
+            this.btnReloadScenes.Icon = global::SuchByte.OBSWebSocketPlugin.Properties.Resources.reload;
+            this.btnReloadScenes.Location = new System.Drawing.Point(555, 40);
+            this.btnReloadScenes.Name = "btnReloadScenes";
+            this.btnReloadScenes.Progress = 0;
+            this.btnReloadScenes.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(46)))), ((int)(((byte)(94)))));
+            this.btnReloadScenes.Size = new System.Drawing.Size(30, 30);
+            this.btnReloadScenes.TabIndex = 17;
+            this.btnReloadScenes.UseVisualStyleBackColor = true;
+            this.btnReloadScenes.UseWindowsAccentColor = true;
+            this.btnReloadScenes.Click += new System.EventHandler(this.BtnReloadScenes_Click);
+            // 
+            // scenesBox
+            // 
+            this.scenesBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.scenesBox.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.scenesBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.scenesBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.scenesBox.Icon = null;
+            this.scenesBox.Location = new System.Drawing.Point(248, 40);
+            this.scenesBox.Name = "scenesBox";
+            this.scenesBox.Padding = new System.Windows.Forms.Padding(8, 2, 8, 2);
+            this.scenesBox.SelectedIndex = -1;
+            this.scenesBox.SelectedItem = null;
+            this.scenesBox.Size = new System.Drawing.Size(301, 30);
+            this.scenesBox.TabIndex = 16;
+            this.scenesBox.SelectedIndexChanged += new System.EventHandler(this.ScenesBox_SelectedIndexChanged);
+            // 
+            // lblScene
+            // 
+            this.lblScene.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblScene.Location = new System.Drawing.Point(129, 40);
+            this.lblScene.Name = "lblScene";
+            this.lblScene.Size = new System.Drawing.Size(113, 30);
+            this.lblScene.TabIndex = 15;
+            this.lblScene.Text = "Scene:";
+            this.lblScene.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // filtersBox
+            // 
+            this.filtersBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.filtersBox.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.filtersBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.filtersBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.filtersBox.Icon = null;
+            this.filtersBox.Location = new System.Drawing.Point(248, 112);
+            this.filtersBox.Name = "filtersBox";
+            this.filtersBox.Padding = new System.Windows.Forms.Padding(8, 2, 8, 2);
+            this.filtersBox.SelectedIndex = -1;
+            this.filtersBox.SelectedItem = null;
+            this.filtersBox.Size = new System.Drawing.Size(301, 30);
+            this.filtersBox.TabIndex = 18;
+            // 
+            // lblFilter
+            // 
+            this.lblFilter.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblFilter.Location = new System.Drawing.Point(129, 112);
+            this.lblFilter.Name = "lblFilter";
+            this.lblFilter.Size = new System.Drawing.Size(113, 30);
+            this.lblFilter.TabIndex = 19;
+            this.lblFilter.Text = "Filter:";
+            this.lblFilter.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // btnReloadFilters
+            // 
+            this.btnReloadFilters.BorderRadius = 8;
+            this.btnReloadFilters.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnReloadFilters.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReloadFilters.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnReloadFilters.ForeColor = System.Drawing.Color.White;
+            this.btnReloadFilters.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(89)))), ((int)(((byte)(184)))));
+            this.btnReloadFilters.Icon = global::SuchByte.OBSWebSocketPlugin.Properties.Resources.reload;
+            this.btnReloadFilters.Location = new System.Drawing.Point(555, 113);
+            this.btnReloadFilters.Name = "btnReloadFilters";
+            this.btnReloadFilters.Progress = 0;
+            this.btnReloadFilters.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(46)))), ((int)(((byte)(94)))));
+            this.btnReloadFilters.Size = new System.Drawing.Size(30, 30);
+            this.btnReloadFilters.TabIndex = 20;
+            this.btnReloadFilters.UseVisualStyleBackColor = true;
+            this.btnReloadFilters.UseWindowsAccentColor = true;
+            // 
+            // FilterSelector
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnReloadFilters);
+            this.Controls.Add(this.lblFilter);
+            this.Controls.Add(this.filtersBox);
+            this.Controls.Add(this.btnReloadScenes);
+            this.Controls.Add(this.scenesBox);
+            this.Controls.Add(this.lblScene);
+            this.Controls.Add(this.btnReloadSources);
+            this.Controls.Add(this.sourcesBox);
+            this.Controls.Add(this.lblSource);
+            this.Controls.Add(this.radioToggle);
+            this.Controls.Add(this.radioShow);
+            this.Controls.Add(this.radioHide);
+            this.Name = "FilterSelector";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private MacroDeck.GUI.CustomControls.ButtonPrimary btnReloadSources;
+        private MacroDeck.GUI.CustomControls.RoundedComboBox sourcesBox;
+        private System.Windows.Forms.Label lblSource;
+        private System.Windows.Forms.RadioButton radioToggle;
+        private System.Windows.Forms.RadioButton radioShow;
+        private System.Windows.Forms.RadioButton radioHide;
+        private MacroDeck.GUI.CustomControls.ButtonPrimary btnReloadScenes;
+        private MacroDeck.GUI.CustomControls.RoundedComboBox scenesBox;
+        private System.Windows.Forms.Label lblScene;
+        private MacroDeck.GUI.CustomControls.RoundedComboBox filtersBox;
+        private System.Windows.Forms.Label lblFilter;
+        private MacroDeck.GUI.CustomControls.ButtonPrimary btnReloadFilters;
+    }
+}

--- a/GUI/FilterSelector.cs
+++ b/GUI/FilterSelector.cs
@@ -1,0 +1,191 @@
+﻿using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet.Types;
+using SuchByte.MacroDeck.GUI;
+using SuchByte.MacroDeck.GUI.CustomControls;
+using SuchByte.MacroDeck.Language;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.OBSWebSocketPlugin.Language;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace SuchByte.OBSWebSocketPlugin.GUI
+{
+    public partial class FilterSelector : ActionConfigControl
+    {
+
+        PluginAction pluginAction;
+
+        public FilterSelector(PluginAction pluginAction, ActionConfigurator actionConfigurator)
+        {
+            this.pluginAction = pluginAction;
+            InitializeComponent();
+
+            this.lblScene.Text = PluginLanguageManager.PluginStrings.Scene;
+            this.lblSource.Text = PluginLanguageManager.PluginStrings.Source;
+            this.lblFilter.Text = PluginLanguageManager.PluginStrings.Filter;
+            this.radioHide.Text = PluginLanguageManager.PluginStrings.Disable;
+            this.radioShow.Text = PluginLanguageManager.PluginStrings.Enable;
+            this.radioToggle.Text = PluginLanguageManager.PluginStrings.Toggle;
+
+            LoadScenes();
+            LoadConfig();
+        }
+
+        public override bool OnActionSave()
+        {
+            if (String.IsNullOrWhiteSpace(this.filtersBox.Text))
+            {
+                return false;
+            }
+            string method = "toggle";
+            if (this.radioHide.Checked)
+            {
+                method = "hide";
+            }
+            else if (this.radioShow.Checked)
+            {
+                method = "show";
+            }
+            else if (this.radioToggle.Checked)
+            {
+                method = "toggle";
+            }
+            JObject configurationObject = JObject.FromObject(new
+            {
+                sceneName = this.scenesBox.Text,
+                sourceName = this.sourcesBox.Text,
+                filterName = this.filtersBox.Text,
+                method = method,
+            });
+
+            this.pluginAction.Configuration = configurationObject.ToString();
+            this.pluginAction.ConfigurationSummary = method + " " + (String.IsNullOrWhiteSpace(this.sourcesBox.Text) ? this.scenesBox.Text : this.sourcesBox.Text) + "/" + this.filtersBox.Text;
+            return true;
+        }
+
+        private void LoadScenes()
+        {
+            if (!PluginInstance.Main.OBS.IsConnected)
+            {
+                using (var msgBox = new MacroDeck.GUI.CustomControls.MessageBox())
+                {
+                    msgBox.ShowDialog(LanguageManager.Strings.Error, PluginLanguageManager.PluginStrings.ErrorNotConnected, System.Windows.Forms.MessageBoxButtons.OK);
+                }
+                return;
+            }
+
+            this.scenesBox.Items.Clear();
+            this.scenesBox.Text = String.Empty;
+
+            foreach (OBSScene scene in PluginInstance.Main.OBS.ListScenes().ToArray())
+            {
+                this.scenesBox.Items.Add(scene.Name);
+            }
+            
+            LoadSources();
+        }
+
+        private void LoadSources()
+        {
+            if (!PluginInstance.Main.OBS.IsConnected)
+            {
+                using (var msgBox = new MacroDeck.GUI.CustomControls.MessageBox())
+                {
+                    msgBox.ShowDialog(LanguageManager.Strings.Error, PluginLanguageManager.PluginStrings.ErrorNotConnected, System.Windows.Forms.MessageBoxButtons.OK);
+                }
+                return;
+            }
+
+            this.sourcesBox.Items.Clear();
+            this.sourcesBox.Text = String.Empty;
+
+            foreach (var sceneItem in PluginInstance.Main.OBS.GetSceneItemList(this.scenesBox.Text))
+            {
+                this.sourcesBox.Items.Add(sceneItem.SourceName);
+            }
+
+            LoadFilters();
+        }
+
+        private void LoadFilters()
+        {
+            if (!PluginInstance.Main.OBS.IsConnected)
+            {
+                using (var msgBox = new MacroDeck.GUI.CustomControls.MessageBox())
+                {
+                    msgBox.ShowDialog(LanguageManager.Strings.Error, PluginLanguageManager.PluginStrings.ErrorNotConnected, System.Windows.Forms.MessageBoxButtons.OK);
+                }
+                return;
+            }
+
+            this.filtersBox.Items.Clear();
+            this.filtersBox.Text = String.Empty;
+
+            if (String.IsNullOrWhiteSpace(this.scenesBox.Text) && String.IsNullOrWhiteSpace(this.sourcesBox.Text))
+            {
+                return;
+            }
+
+            foreach (var filterItem in PluginInstance.Main.OBS.GetSourceFilters(String.IsNullOrWhiteSpace(this.sourcesBox.Text) ? this.scenesBox.Text : this.sourcesBox.Text))
+            {
+                this.filtersBox.Items.Add(filterItem.Name);
+            }
+
+        }
+
+        private void LoadConfig()
+        {
+            if (!String.IsNullOrWhiteSpace(this.pluginAction.Configuration))
+            {
+                try
+                {
+                    JObject configurationObject = JObject.Parse(this.pluginAction.Configuration);
+                    this.scenesBox.Text = configurationObject["sceneName"].ToString();
+                    this.sourcesBox.Text = configurationObject["sourceName"].ToString();
+                    this.filtersBox.Text = configurationObject["filterName"].ToString();
+
+                    switch (configurationObject["method"].ToString())
+                    {
+                        case "hide":
+                            this.radioHide.Checked = true;
+                            break;
+                        case "show":
+                            this.radioShow.Checked = true;
+                            break;
+                        case "toggle":
+                            this.radioToggle.Checked = true;
+                            break;
+                    }
+                }
+                catch { }
+            }
+        }
+
+
+        private void BtnReloadScenes_Click(object sender, EventArgs e)
+        {
+            LoadScenes();
+        }
+
+        private void BtnReloadSources_Click(object sender, EventArgs e)
+        {
+            LoadSources();
+        }
+
+        private void ScenesBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            LoadSources();
+        }
+
+        private void sourcesBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            LoadFilters();
+        }
+
+    }
+}

--- a/GUI/FilterSelector.resx
+++ b/GUI/FilterSelector.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Language/PluginStrings.cs
+++ b/Language/PluginStrings.cs
@@ -13,6 +13,8 @@ namespace SuchByte.OBSWebSocketPlugin.Language
 
         public string ActionSourceVisibility = "Set OBS source visibility";
         public string ActionSourceVisibilityDescription = "Hide/show/toggle scene source visibility";
+        public string ActionFilterState = "Set OBS filter state";
+        public string ActionFilterStateDescription = "Enable/disable/toggle filter state";
         public string ActionSetAudioMuted = "Set OBS audio source mute";
         public string ActionSetAudioMutedDescription = "Mute/unmute/toggle audio source";
         public string ActionSetSourceVolume = "Set OBS source volume";
@@ -51,6 +53,9 @@ namespace SuchByte.OBSWebSocketPlugin.Language
         public string Stop = "Stop";
         public string Hide = "Hide";
         public string Show = "Show";
+        public string Filter = "Filter";
+        public string Enable = "Enable";
+        public string Disable = "Disable";
         public string OBSConnected = "OBS connected";
         public string OBSDisconnected = "OBS disconnected";
         public string ActionSaveReplayBuffer = "Save replay buffer";

--- a/Main.cs
+++ b/Main.cs
@@ -87,6 +87,7 @@ namespace SuchByte.OBSWebSocketPlugin {
                 new SetReplayBufferState(),
                 new SaveReplayBufferAction(),
                 new SourceVisibilityAction(),
+                new SetFilterStateAction(),
                 new SetSourceVolumeAction(),
                 new SetAudioMutedAction(),
                 new SetProfileAction(),

--- a/Resources/Languages/English.xml
+++ b/Resources/Languages/English.xml
@@ -6,6 +6,8 @@
 
 	<ActionSourceVisibility>Set OBS source visibility</ActionSourceVisibility>
 	<ActionSourceVisibilityDescription>Hide/show/toggle scene source visibility</ActionSourceVisibilityDescription>
+	<ActionFilterState>Set OBS filter state</ActionFilterState>
+	<ActionFilterStateDescription>Enable/disable/toggle filter state</ActionFilterStateDescription>
 	<ActionSetAudioMuted>Set OBS audio source mute</ActionSetAudioMuted>
 	<ActionSetAudioMutedDescription>Mute/unmute/toggle audio source</ActionSetAudioMutedDescription>
 	<ActionSetSourceVolume>Set OBS source volume</ActionSetSourceVolume>
@@ -44,6 +46,9 @@
 	<Stop>Stop</Stop>
 	<Hide>Hide</Hide>
 	<Show>Show</Show>
+	<Filter>Filter</Filter>
+	<Enable>Enable</Enable>
+	<Disable>Disable</Disable>
 	<OBSConnected>OBS connected</OBSConnected>
 	<OBSDisconnected>OBS disconnected</OBSDisconnected>
 	<ActionSaveReplayBuffer>Save replay buffer</ActionSaveReplayBuffer>


### PR DESCRIPTION
Adds the ability to enable/disable/toggle filters (source or scene filters) as an action.

Example usecases:
- have a "reverb" filter on the microphone, disabled by default, enabled for dramatic effect (source filter)
- move a camera source when it obstructs the view (scene filter)