### PR TITLE
Added set text value action

### DIFF
--- a/Actions/SetTextValueAction.cs
+++ b/Actions/SetTextValueAction.cs
@@ -1,0 +1,50 @@
+﻿using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet.Types;
+using SuchByte.MacroDeck.ActionButton;
+using SuchByte.MacroDeck.GUI;
+using SuchByte.MacroDeck.GUI.CustomControls;
+using SuchByte.MacroDeck.Logging;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.MacroDeck.Variables;
+using SuchByte.MacroDeck.Variables.Plugin.GUI;
+using SuchByte.OBSWebSocketPlugin.GUI;
+using SuchByte.OBSWebSocketPlugin.Language;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SuchByte.OBSWebSocketPlugin.Actions
+{
+    public class SetTextValueAction : PluginAction
+    {
+        public override string Name => PluginLanguageManager.PluginStrings.ActionSetTextValue;
+
+        public override string Description => PluginLanguageManager.PluginStrings.ActionSetTextValueDescription;
+
+        public override bool CanConfigure => true;
+
+        public override void Trigger(string clientId, ActionButton actionButton)
+        {
+            if (!PluginInstance.Main.OBS.IsConnected) return;
+            if (!String.IsNullOrWhiteSpace(this.Configuration))
+            {
+                try
+                {
+                    JObject configurationObject = JObject.Parse(this.Configuration);
+                    string sourceName = configurationObject["sourceName"].ToString();
+                    string value = configurationObject["value"].ToString();
+
+                    TextGDIPlusProperties properties = PluginInstance.Main.OBS.GetTextGDIPlusProperties(sourceName);
+                    properties.Text = VariableManager.RenderTemplate(value);
+                    PluginInstance.Main.OBS.SetTextGDIPlusProperties(properties);
+                }
+                catch { }
+            }
+        }
+
+        public override ActionConfigControl GetActionConfigControl(ActionConfigurator actionConfigurator)
+        {
+            return new SetTextValueConfigurator(this, actionConfigurator);
+        }
+    }
+}

--- a/GUI/SetTextValueConfigurator.Designer.cs
+++ b/GUI/SetTextValueConfigurator.Designer.cs
@@ -1,0 +1,211 @@
+﻿
+using SuchByte.MacroDeck.GUI.CustomControls;
+
+namespace SuchByte.OBSWebSocketPlugin.GUI
+{
+    partial class SetTextValueConfigurator
+    {
+        /// <summary> 
+        /// Erforderliche Designervariable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Verwendete Ressourcen bereinigen.
+        /// </summary>
+        /// <param name="disposing">True, wenn verwaltete Ressourcen gelöscht werden sollen; andernfalls False.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Vom Komponenten-Designer generierter Code
+
+        /// <summary> 
+        /// Erforderliche Methode für die Designerunterstützung. 
+        /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SetTextValueConfigurator));
+            this.value = new SuchByte.MacroDeck.GUI.CustomControls.RoundedTextBox();
+            this.lblVariable = new System.Windows.Forms.Label();
+            this.btnTemplateEditor = new SuchByte.MacroDeck.GUI.CustomControls.PictureButton();
+            this.btnReloadScenes = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
+            this.scenesBox = new SuchByte.MacroDeck.GUI.CustomControls.RoundedComboBox();
+            this.lblScene = new System.Windows.Forms.Label();
+            this.btnReloadSources = new SuchByte.MacroDeck.GUI.CustomControls.ButtonPrimary();
+            this.sourcesBox = new SuchByte.MacroDeck.GUI.CustomControls.RoundedComboBox();
+            this.lblSource = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.btnTemplateEditor)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // value
+            // 
+            this.value.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.value.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.value.Font = new System.Drawing.Font("Tahoma", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.value.Icon = null;
+            this.value.Location = new System.Drawing.Point(298, 194);
+            this.value.MaxCharacters = 32767;
+            this.value.Multiline = false;
+            this.value.Name = "value";
+            this.value.Padding = new System.Windows.Forms.Padding(8, 5, 8, 5);
+            this.value.PasswordChar = false;
+            this.value.PlaceHolderColor = System.Drawing.Color.Gray;
+            this.value.PlaceHolderText = "";
+            this.value.ReadOnly = false;
+            this.value.ScrollBars = System.Windows.Forms.ScrollBars.None;
+            this.value.SelectionStart = 0;
+            this.value.Size = new System.Drawing.Size(171, 25);
+            this.value.TabIndex = 2;
+            this.value.TextAlignment = System.Windows.Forms.HorizontalAlignment.Left;
+            // 
+            // lblVariable
+            // 
+            this.lblVariable.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblVariable.Location = new System.Drawing.Point(126, 196);
+            this.lblVariable.Name = "lblVariable";
+            this.lblVariable.Size = new System.Drawing.Size(166, 23);
+            this.lblVariable.TabIndex = 4;
+            this.lblVariable.Text = "Value";
+            this.lblVariable.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // btnTemplateEditor
+            // 
+            this.btnTemplateEditor.BackColor = System.Drawing.Color.Transparent;
+            this.btnTemplateEditor.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("btnTemplateEditor.BackgroundImage")));
+            this.btnTemplateEditor.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            this.btnTemplateEditor.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnTemplateEditor.HoverImage = ((System.Drawing.Image)(resources.GetObject("btnTemplateEditor.HoverImage")));
+            this.btnTemplateEditor.Location = new System.Drawing.Point(470, 194);
+            this.btnTemplateEditor.Name = "btnTemplateEditor";
+            this.btnTemplateEditor.Size = new System.Drawing.Size(25, 25);
+            this.btnTemplateEditor.TabIndex = 6;
+            this.btnTemplateEditor.TabStop = false;
+            this.btnTemplateEditor.Click += new System.EventHandler(this.btnTemplateEditor_Click);
+            // 
+            // btnReloadScenes
+            // 
+            this.btnReloadScenes.BorderRadius = 8;
+            this.btnReloadScenes.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnReloadScenes.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReloadScenes.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnReloadScenes.ForeColor = System.Drawing.Color.White;
+            this.btnReloadScenes.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(89)))), ((int)(((byte)(184)))));
+            this.btnReloadScenes.Icon = global::SuchByte.OBSWebSocketPlugin.Properties.Resources.reload;
+            this.btnReloadScenes.Location = new System.Drawing.Point(605, 113);
+            this.btnReloadScenes.Name = "btnReloadScenes";
+            this.btnReloadScenes.Progress = 0;
+            this.btnReloadScenes.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(46)))), ((int)(((byte)(94)))));
+            this.btnReloadScenes.Size = new System.Drawing.Size(30, 30);
+            this.btnReloadScenes.TabIndex = 23;
+            this.btnReloadScenes.UseVisualStyleBackColor = true;
+            this.btnReloadScenes.UseWindowsAccentColor = true;
+            this.btnReloadScenes.Click += new System.EventHandler(this.BtnReloadScenes_Click);
+            // 
+            // scenesBox
+            // 
+            this.scenesBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.scenesBox.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.scenesBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.scenesBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.scenesBox.Icon = null;
+            this.scenesBox.Location = new System.Drawing.Point(298, 113);
+            this.scenesBox.Name = "scenesBox";
+            this.scenesBox.Padding = new System.Windows.Forms.Padding(8, 2, 8, 2);
+            this.scenesBox.SelectedIndex = -1;
+            this.scenesBox.SelectedItem = null;
+            this.scenesBox.Size = new System.Drawing.Size(301, 30);
+            this.scenesBox.TabIndex = 22;
+            this.scenesBox.SelectedIndexChanged += new System.EventHandler(this.ScenesBox_SelectedIndexChanged);
+            // 
+            // lblScene
+            // 
+            this.lblScene.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblScene.Location = new System.Drawing.Point(179, 113);
+            this.lblScene.Name = "lblScene";
+            this.lblScene.Size = new System.Drawing.Size(113, 30);
+            this.lblScene.TabIndex = 21;
+            this.lblScene.Text = "Scene:";
+            this.lblScene.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // btnReloadSources
+            // 
+            this.btnReloadSources.BorderRadius = 8;
+            this.btnReloadSources.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.btnReloadSources.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnReloadSources.Font = new System.Drawing.Font("Tahoma", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.btnReloadSources.ForeColor = System.Drawing.Color.White;
+            this.btnReloadSources.HoverColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(89)))), ((int)(((byte)(184)))));
+            this.btnReloadSources.Icon = global::SuchByte.OBSWebSocketPlugin.Properties.Resources.reload;
+            this.btnReloadSources.Location = new System.Drawing.Point(605, 149);
+            this.btnReloadSources.Name = "btnReloadSources";
+            this.btnReloadSources.Progress = 0;
+            this.btnReloadSources.ProgressColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(46)))), ((int)(((byte)(94)))));
+            this.btnReloadSources.Size = new System.Drawing.Size(30, 30);
+            this.btnReloadSources.TabIndex = 20;
+            this.btnReloadSources.UseVisualStyleBackColor = true;
+            this.btnReloadSources.UseWindowsAccentColor = true;
+            this.btnReloadSources.Click += new System.EventHandler(this.BtnReloadSources_Click);
+            // 
+            // sourcesBox
+            // 
+            this.sourcesBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(65)))), ((int)(((byte)(65)))), ((int)(((byte)(65)))));
+            this.sourcesBox.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.sourcesBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.sourcesBox.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.sourcesBox.Icon = null;
+            this.sourcesBox.Location = new System.Drawing.Point(298, 149);
+            this.sourcesBox.Name = "sourcesBox";
+            this.sourcesBox.Padding = new System.Windows.Forms.Padding(8, 2, 8, 2);
+            this.sourcesBox.SelectedIndex = -1;
+            this.sourcesBox.SelectedItem = null;
+            this.sourcesBox.Size = new System.Drawing.Size(301, 30);
+            this.sourcesBox.TabIndex = 19;
+            // 
+            // lblSource
+            // 
+            this.lblSource.Font = new System.Drawing.Font("Tahoma", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.lblSource.Location = new System.Drawing.Point(179, 149);
+            this.lblSource.Name = "lblSource";
+            this.lblSource.Size = new System.Drawing.Size(113, 30);
+            this.lblSource.TabIndex = 18;
+            this.lblSource.Text = "Source:";
+            this.lblSource.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // SetTextValueConfigurator
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 23F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.btnReloadScenes);
+            this.Controls.Add(this.scenesBox);
+            this.Controls.Add(this.lblScene);
+            this.Controls.Add(this.btnReloadSources);
+            this.Controls.Add(this.sourcesBox);
+            this.Controls.Add(this.lblSource);
+            this.Controls.Add(this.btnTemplateEditor);
+            this.Controls.Add(this.lblVariable);
+            this.Controls.Add(this.value);
+            this.Name = "SetTextValueConfigurator";
+            ((System.ComponentModel.ISupportInitialize)(this.btnTemplateEditor)).EndInit();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+        private RoundedTextBox value;
+        private System.Windows.Forms.Label lblVariable;
+        private PictureButton btnTemplateEditor;
+        private ButtonPrimary btnReloadScenes;
+        private RoundedComboBox scenesBox;
+        private System.Windows.Forms.Label lblScene;
+        private ButtonPrimary btnReloadSources;
+        private RoundedComboBox sourcesBox;
+        private System.Windows.Forms.Label lblSource;
+    }
+}

--- a/GUI/SetTextValueConfigurator.cs
+++ b/GUI/SetTextValueConfigurator.cs
@@ -1,0 +1,142 @@
+﻿using Newtonsoft.Json.Linq;
+using OBSWebsocketDotNet.Types;
+using SuchByte.MacroDeck.GUI;
+using SuchByte.MacroDeck.GUI.CustomControls;
+using SuchByte.MacroDeck.GUI.Dialogs;
+using SuchByte.MacroDeck.Language;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.OBSWebSocketPlugin;
+using SuchByte.OBSWebSocketPlugin.Language;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Diagnostics;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace SuchByte.OBSWebSocketPlugin.GUI
+{
+    public partial class SetTextValueConfigurator : ActionConfigControl
+    {
+        PluginAction pluginAction;
+
+        public SetTextValueConfigurator(PluginAction pluginAction, ActionConfigurator actionConfigurator)
+        {
+            this.pluginAction = pluginAction;
+            InitializeComponent();
+
+            LoadScenes();
+            LoadConfig();
+        }
+
+        public override bool OnActionSave()
+        {
+            if (String.IsNullOrWhiteSpace(this.sourcesBox.Text))
+            {
+                return false;
+            }
+
+            JObject configurationObject = JObject.FromObject(new
+            {
+                sceneName = this.scenesBox.Text,
+                sourceName = this.sourcesBox.Text,
+                value = this.value.Text,
+            });
+
+            this.pluginAction.Configuration = configurationObject.ToString();
+            this.pluginAction.ConfigurationSummary = this.sourcesBox.Text + "=" + this.value.Text;
+            return true;
+        }
+
+        private void LoadScenes()
+        {
+            if (!PluginInstance.Main.OBS.IsConnected)
+            {
+                using (var msgBox = new MacroDeck.GUI.CustomControls.MessageBox())
+                {
+                    msgBox.ShowDialog(LanguageManager.Strings.Error, PluginLanguageManager.PluginStrings.ErrorNotConnected, System.Windows.Forms.MessageBoxButtons.OK);
+                }
+                return;
+            }
+
+            this.scenesBox.Items.Clear();
+            this.scenesBox.Text = String.Empty;
+
+            foreach (OBSScene scene in PluginInstance.Main.OBS.ListScenes().ToArray())
+            {
+                this.scenesBox.Items.Add(scene.Name);
+            }
+
+            LoadSources();
+        }
+
+        private void LoadSources()
+        {
+            if (!PluginInstance.Main.OBS.IsConnected)
+            {
+                using (var msgBox = new MacroDeck.GUI.CustomControls.MessageBox())
+                {
+                    msgBox.ShowDialog(LanguageManager.Strings.Error, PluginLanguageManager.PluginStrings.ErrorNotConnected, System.Windows.Forms.MessageBoxButtons.OK);
+                }
+                return;
+            }
+
+            this.sourcesBox.Items.Clear();
+            this.sourcesBox.Text = String.Empty;
+
+            if (String.IsNullOrWhiteSpace(this.scenesBox.Text))
+            {
+                return;
+            }
+
+                foreach (var sceneItem in PluginInstance.Main.OBS.GetSceneItemList(this.scenesBox.Text))
+            {
+                this.sourcesBox.Items.Add(sceneItem.SourceName);
+            }
+
+        }
+
+        private void LoadConfig()
+        {
+            if (!String.IsNullOrWhiteSpace(this.pluginAction.Configuration))
+            {
+                try
+                {
+                    JObject configurationObject = JObject.Parse(this.pluginAction.Configuration);
+                    this.scenesBox.Text = configurationObject["sceneName"].ToString();
+                    this.sourcesBox.Text = configurationObject["sourceName"].ToString();
+                    this.value.Text = configurationObject["value"].ToString();
+                }
+                catch { }
+            }
+        }
+
+        private void BtnReloadScenes_Click(object sender, EventArgs e)
+        {
+            LoadScenes();
+        }
+
+        private void BtnReloadSources_Click(object sender, EventArgs e)
+        {
+            LoadSources();
+        }
+
+        private void ScenesBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            LoadSources();
+        }
+
+        private void btnTemplateEditor_Click(object sender, EventArgs e)
+        {
+            using (var templateEditor = new TemplateEditor(this.value.Text))
+            {
+                if (templateEditor.ShowDialog() == DialogResult.OK)
+                {
+                    this.value.Text = templateEditor.Template;
+                }
+            }
+        }
+    }
+}

--- a/GUI/SetTextValueConfigurator.resx
+++ b/GUI/SetTextValueConfigurator.resx
@@ -1,0 +1,85 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="btnTemplateEditor.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAu
+        IgAALiIBquLdkgAAAWtJREFUWEft1rtKA0EUxvF0dmJnFbGwVRsFm4C1rU/gI1jFh/ECWojgE/gO2whe
+        IMYbioWgYGEVsv4/mMDucVbDzuzEwuIHmTPnzJxshs208jyfKG8wJW8wJW8wpW+BLMvmcIRzXOEikNbQ
+        WlqzbfcrDYSkfeQN2bP7lQZCUs8UxdSz+5UGQlLfFMXUt/uVBkLSxJ/An27gAzrNxzitcIZP+OqDG3jF
+        pq0pYn4Gty7fivYTdDFla139Ih5dnhX1DCzZWlefpAE9gWlb6+obbWCIrq0pYr6xBrT5js23yFlG9Abe
+        UfnNmdvAtvs8jyfYNaR2Ayc2b4S5DvR+UN4WZnHpxlbtBq7R8eSu4dnlyAAH0F9wsX4k6Ay8Yb2Qt4oX
+        N2fpvPjiQQ2ImljBAqredj8JbkAecGNi44rSQIixGvi/kDR5Kd21+5UGQlIbh9CVWgfuHnc1qVZraC2t
+        +fu1PDVvMCVvMCVvMJ289QXVgZ3u2wBK0AAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="btnTemplateEditor.HoverImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAu
+        IgAALiIBquLdkgAAAVdJREFUWEft1rtKBDEYxfHt7MTOSrGwVRsFG8Ha1ifwEaz0YbyAFiL4BD6G4AW8
+        i2IhKFhYieP/aAaMnl3WySZr4YEfTMLky7fDMJtWVVV9ZSdLspMl2cmS3OQotnGAYxwmUg3VUs0RRPtF
+        g2ADubKOaL9oEJwiV1Q72i8aBOfIFdWO9osGQd+fwJ9u4Bl6m3ew18Y+XuCS3MADFuHW1YZwAZfkBuqs
+        YABu/QRu4NKzBpRJuPVFGtATGIRbn7WBN2hzt66WrQFtvgq35qsp9LyBJ3T65QtYDtdjuIVL4wZ24e6V
+        Oej7oCxhGEcfo59p3MAJtNH3e2dxhzqv2IT+gl0aN6A8Yh71fTO4h4veF5ekBhQ1MY1xtPvadUpyA8o1
+        zj4vf52eNJCSrhr4P5DkPJSuIdovGgQ6Om9BR2q9cFe4bEhrVUO1VLOrY3lRdrIkO1mSnSynar0DfaXO
+        rRYol3EAAAAASUVORK5CYII=
+</value>
+  </data>
+</root>

--- a/Language/PluginStrings.cs
+++ b/Language/PluginStrings.cs
@@ -19,6 +19,8 @@ namespace SuchByte.OBSWebSocketPlugin.Language
         public string ActionSetAudioMutedDescription = "Mute/unmute/toggle audio source";
         public string ActionSetSourceVolume = "Set OBS source volume";
         public string ActionSetSourceVolumeDescription = "Set the volume of an audio source";
+        public string ActionSetTextValue = "Set OBS text source value";
+        public string ActionSetTextValueDescription = "Set the value of a text (GDI+) source";
         public string ActionSetProfile = "Set OBS profile";
         public string ActionSetProfileDescription = "Set the profile of OBS";
         public string ActionSetRecordingState = "Set OBS recording state";

--- a/Main.cs
+++ b/Main.cs
@@ -88,6 +88,7 @@ namespace SuchByte.OBSWebSocketPlugin {
                 new SaveReplayBufferAction(),
                 new SourceVisibilityAction(),
                 new SetFilterStateAction(),
+                new SetTextValueAction(),
                 new SetSourceVolumeAction(),
                 new SetAudioMutedAction(),
                 new SetProfileAction(),

--- a/Resources/Languages/English.xml
+++ b/Resources/Languages/English.xml
@@ -12,6 +12,8 @@
 	<ActionSetAudioMutedDescription>Mute/unmute/toggle audio source</ActionSetAudioMutedDescription>
 	<ActionSetSourceVolume>Set OBS source volume</ActionSetSourceVolume>
 	<ActionSetSourceVolumeDescription>Set the volume of an audio source</ActionSetSourceVolumeDescription>
+	<ActionSetTextValue>Set OBS text source value</ActionSetTextValue>
+	<ActionSetTextValueDescription>Set the value of a text (GDI+) source</ActionSetTextValueDescription>
 	<ActionSetProfile>Set OBS profile</ActionSetProfile>
 	<ActionSetProfileDescription>Set the profile of OBS</ActionSetProfileDescription>
 	<ActionSetRecordingState>Set OBS recording state</ActionSetRecordingState>


### PR DESCRIPTION
Adds the ability to change the value of a text source (GDI+) as an action.
Problem (minor?), when creating a text source without explicitely giving it a color then using this action, the color will be set to black. Workaround: just set the color on OBS at least once and this action should respect that choice.

Example usecase: death counter in die-and-retry games.